### PR TITLE
Move `operator-framework-spring-boot-starter-test` into this project as a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ target
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Intellij Idea
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1,71 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.javaoperatorsdk</groupId>
-  <artifactId>operator-framework-spring-boot-starter-parent</artifactId>
-  <version>1.8.5-SNAPSHOT</version>
-  <name>Java Operator SDK Spring Boot Starter - Parent</name>
-  <packaging>pom</packaging>
-  <url>https://github.com/java-operator-sdk/operator-framework-spring-boot-starter</url>
+    <groupId>io.javaoperatorsdk</groupId>
+    <artifactId>operator-framework-spring-boot-starter-parent</artifactId>
+    <version>1.8.5-SNAPSHOT</version>
+    <name>Java Operator SDK Spring Boot Starter - Parent</name>
+    <packaging>pom</packaging>
+    <url>https://github.com/java-operator-sdk/operator-framework-spring-boot-starter</url>
 
-  <licenses>
-    <license>
-      <name>Apache 2 License</name>
-      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
-    </license>
-  </licenses>
-  <developers>
-    <developer>
-      <name>Adam Sandor</name>
-      <email>adam.sandor@container-solutions.com</email>
-    </developer>
-    <developer>
-      <name>Attila Meszaros</name>
-      <email>csviri@gmail.com</email>
-    </developer>
-  </developers>
+    <licenses>
+        <license>
+            <name>Apache 2 License</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Adam Sandor</name>
+            <email>adam.sandor@container-solutions.com</email>
+        </developer>
+        <developer>
+            <name>Attila Meszaros</name>
+            <email>csviri@gmail.com</email>
+        </developer>
+    </developers>
 
-  <properties>
-    <java.version>11</java.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
-    <josdk.version>1.8.4</josdk.version>
-    <surefire.version>3.0.0-M5</surefire.version>
-  </properties>
+    <properties>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
+        <josdk.version>1.8.4</josdk.version>
+        <surefire.version>3.0.0-M5</surefire.version>
+    </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
-      </plugin>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring-boot.version}</version>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 
-  <modules>
-    <module>starter</module>
-    <module>samples</module>
-  </modules>
+    <modules>
+        <module>starter</module>
+        <module>samples</module>
+        <module>starter-test</module>
+    </modules>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/starter-test/pom.xml
+++ b/starter-test/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>operator-framework-spring-boot-starter-parent</artifactId>
+        <groupId>io.javaoperatorsdk</groupId>
+        <version>1.8.5-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <version>1.8.5-SNAPSHOT</version>
+    <name>Java Operator SDK Spring Boot Starter Test</name>
+    <description>Spring Boot starter test utilities for the Java Operator SDK</description>
+    <artifactId>operator-framework-spring-boot-starter-test</artifactId>
+    <url>https://github.com/java-operator-sdk/operator-framework-spring-boot-starter-test</url>
+
+    <licenses>
+        <license>
+            <name>Apache 2 License</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Adam Sandor</name>
+            <email>adam.sandor@container-solutions.com</email>
+        </developer>
+        <developer>
+            <name>Attila Meszaros</name>
+            <email>csviri@gmail.com</email>
+        </developer>
+    </developers>
+
+    <properties>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <fabric8-client.version>5.6.0</fabric8-client.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.javaoperatorsdk</groupId>
+            <artifactId>operator-framework</artifactId>
+            <version>${josdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <version>${fabric8-client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.javaoperatorsdk</groupId>
+            <artifactId>operator-framework-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
+++ b/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
@@ -1,0 +1,22 @@
+package io.javaoperatorsdk.operator.springboot.starter.test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.boot.test.autoconfigure.properties.PropertyMapping;
+import org.springframework.context.annotation.Import;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Import(TestConfiguration.class)
+@PropertyMapping("javaoperatorsdk.test")
+public @interface EnableMockOperator {
+
+  /**
+   * Define a list of files that contain CustomResourceDefinitions for the tested operator. If the
+   * file to be loaded is shall be loaded from the classpath prefix it with 'classpath', otherwise
+   * provide a path relative to the current working directory.
+   *
+   * @return List of files
+   */
+  @PropertyMapping("crd-paths")
+  String[] crdPaths() default {};
+}

--- a/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
+++ b/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
@@ -1,0 +1,66 @@
+package io.javaoperatorsdk.operator.springboot.starter.test;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.mockwebserver.Context;
+import io.javaoperatorsdk.operator.springboot.starter.OperatorAutoConfiguration;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.stream.Stream;
+import okhttp3.mockwebserver.MockWebServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ResourceUtils;
+
+@Configuration
+@ImportAutoConfiguration(OperatorAutoConfiguration.class)
+@EnableConfigurationProperties(TestConfigurationProperties.class)
+public class TestConfiguration {
+
+  private static final Logger log = LoggerFactory.getLogger(TestConfiguration.class);
+
+  @Bean
+  public KubernetesMockServer k8sMockServer() {
+    final var server =
+        new KubernetesMockServer(
+            new Context(),
+            new MockWebServer(),
+            new HashMap<>(),
+            new KubernetesCrudDispatcher(Collections.emptyList()),
+            true);
+    server.init();
+    return server;
+  }
+
+  @Bean
+  public KubernetesClient kubernetesClient(
+      KubernetesMockServer server, TestConfigurationProperties properties) {
+    final var client = server.createClient();
+
+    Stream.concat(properties.getCrdPaths().stream(), properties.getGlobalCrdPaths().stream())
+        .forEach(
+            crdPath -> {
+              CustomResourceDefinition crd;
+              try {
+                crd = Serialization.unmarshal(new FileInputStream(ResourceUtils.getFile(crdPath)));
+              } catch (FileNotFoundException e) {
+                log.warn("CRD with path {} not found!", crdPath);
+                e.printStackTrace();
+                return;
+              }
+
+              client.apiextensions().v1().customResourceDefinitions().create(crd);
+            });
+
+    return client;
+  }
+}

--- a/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfigurationProperties.java
+++ b/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfigurationProperties.java
@@ -1,0 +1,29 @@
+package io.javaoperatorsdk.operator.springboot.starter.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("javaoperatorsdk.test")
+public class TestConfigurationProperties {
+
+  private List<String> globalCrdPaths = new ArrayList<>();
+
+  private List<String> crdPaths = new ArrayList<>();
+
+  public List<String> getCrdPaths() {
+    return crdPaths;
+  }
+
+  public void setCrdPaths(List<String> crdPaths) {
+    this.crdPaths = crdPaths;
+  }
+
+  public List<String> getGlobalCrdPaths() {
+    return globalCrdPaths;
+  }
+
+  public void setGlobalCrdPaths(List<String> globalCrdPaths) {
+    this.globalCrdPaths = globalCrdPaths;
+  }
+}

--- a/starter-test/src/main/resources/application.properties
+++ b/starter-test/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+javaoperatorsdk.test.global-crd-paths=classpath:global-crd.yml

--- a/starter-test/src/main/resources/crd.yml
+++ b/starter-test/src/main/resources/crd.yml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: customservices.sample.javaoperatorsdk
+spec:
+  group: sample.javaoperatorsdk
+  scope: Namespaced
+  names:
+    plural: customservices
+    singular: customservice
+    kind: CustomService
+    shortNames:
+      - cs
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/starter-test/src/main/resources/global-crd.yml
+++ b/starter-test/src/main/resources/global-crd.yml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: customservices.global.sample.javaoperatorsdk
+spec:
+  group: sample.javaoperatorsdk
+  scope: Namespaced
+  names:
+    plural: customservices
+    singular: customservice
+    kind: CustomService
+    shortNames:
+      - cs
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
+++ b/starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
@@ -1,0 +1,44 @@
+package io.javaoperatorsdk.operator.springboot.starter.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.Operator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.context.ApplicationContext;
+
+@JsonTest
+@EnableMockOperator(crdPaths = "classpath:crd.yml")
+class EnableMockOperatorTests {
+
+  @Autowired KubernetesClient client;
+
+  @Autowired ApplicationContext applicationContext;
+
+  @Test
+  void testCrdLoaded() {
+    assertThat(applicationContext.getBean(Operator.class)).isNotNull();
+    assertThat(
+            client
+                .apiextensions()
+                .v1()
+                .customResourceDefinitions()
+                .withName("customservices.sample.javaoperatorsdk")
+                .get())
+        .isNotNull();
+    assertThat(
+            client
+                .apiextensions()
+                .v1()
+                .customResourceDefinitions()
+                .withName("customservices.global.sample.javaoperatorsdk")
+                .get())
+        .isNotNull();
+  }
+
+  @SpringBootApplication
+  static class SpringBootTestApplication {}
+}

--- a/starter-test/src/test/resources/application.properties
+++ b/starter-test/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+javaoperatorsdk.test.global-crd-paths=classpath:global-crd.yml

--- a/starter-test/src/test/resources/crd.yml
+++ b/starter-test/src/test/resources/crd.yml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: customservices.sample.javaoperatorsdk
+spec:
+  group: sample.javaoperatorsdk
+  scope: Namespaced
+  names:
+    plural: customservices
+    singular: customservice
+    kind: CustomService
+    shortNames:
+      - cs
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/starter-test/src/test/resources/global-crd.yml
+++ b/starter-test/src/test/resources/global-crd.yml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: customservices.global.sample.javaoperatorsdk
+spec:
+  group: sample.javaoperatorsdk
+  scope: Namespaced
+  names:
+    plural: customservices
+    singular: customservice
+    kind: CustomService
+    shortNames:
+      - cs
+  versions:
+    - name: v1
+      served: true
+      storage: true


### PR DESCRIPTION
* Move sources, tests and files from `operator-framework-spring-boot-starter-test` project to `operator-framework-spring-boot-starter`
* Update `fabric8-client.version` to 5.6.0 in `operator-framework-spring-boot-starter-test`. The curent version uses TLS 1.0 which fails to run because TLS 1.0 is deprecated and fails to run on some computers.
* Add Intellij IDEA specific files in .gitignore

Fixes #1 

----
### Rationale

Projects have many dependencies between each other which makes build difficult. For example `operator-framework-spring-boot-starter-test` can not be built without `operator-framework-spring-boot-starter` dependency. In order to build it `operator-framework-spring-boot-starter-test` should depend on a release version of `operator-framework-spring-boot-starter` what requires to have separate release cycles for both projects.