### PR TITLE
feat: Support arbitrary config customization by users

### DIFF
--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/KubernetesClientProperties.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/KubernetesClientProperties.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 public class KubernetesClientProperties {
 
   private boolean openshift = false;
+  private String context;
   private String username;
   private String password;
   private String masterUrl;
@@ -17,6 +18,14 @@ public class KubernetesClientProperties {
   public KubernetesClientProperties setOpenshift(boolean openshift) {
     this.openshift = openshift;
     return this;
+  }
+
+  public Optional<String> getContext() {
+    return Optional.ofNullable(context);
+  }
+
+  public void setContext(String context) {
+    this.context = context;
   }
 
   public Optional<String> getUsername() {

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/KubernetesConfigCustomizer.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/KubernetesConfigCustomizer.java
@@ -1,0 +1,13 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import io.fabric8.kubernetes.client.ConfigBuilder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to further customize the
+ * {@link ConfigBuilder}.
+ */
+@FunctionalInterface
+public interface KubernetesConfigCustomizer {
+
+  void customize(ConfigBuilder configBuilder);
+}


### PR DESCRIPTION
Petting two birds with one hand on this one.

1. Adding support for users to customize their `Config` without extending `OperatorAutoConfiguration` via a `KubernetesConfigCustomizer` interface - this follows a familiar pattern in Spring for third-party configs (e.g. Spring's Jackson integration).
2. Adding support for configuring the client via a context name.