### PR TITLE
feat: support customizing context-based configs

### DIFF
--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
@@ -64,6 +64,15 @@ public class OperatorAutoConfiguration extends AbstractConfigurationService {
   public Config getClientConfiguration() {
     return configuration.getClient().getContext()
         .map(Config::autoConfigure)
+        .map(it -> {
+          if (configCustomizer != null) {
+            final var builder = new ConfigBuilder(it);
+            configCustomizer.customize(builder);
+            return builder.build();
+          } else {
+            return it;
+          }
+        })
         .orElseGet(() -> {
           final var clientCfg = configuration.getClient();
           ConfigBuilder config = new ConfigBuilder();


### PR DESCRIPTION
This allows the `KubernetesConfigCustomizer` to be used even when a config context is provided.

Sorry to have made multiple PRs for this. I've improved my local development process so these pile-on PRs shouldn't happen in the future. 