### PR TITLE
fix: incompatible fabric8-server-mock version with operator-framework-core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <spring-boot.version>2.7.0</spring-boot.version>
         <josdk.version>3.0.2</josdk.version>
         <surefire.version>3.0.0-M5</surefire.version>
-        <fabric8-client.version>5.11.2</fabric8-client.version>
+        <fabric8-client.version>5.12.2</fabric8-client.version>
         <formatter-maven-plugin.version>2.17.1</formatter-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <impsort-maven-plugin.version>1.6.2</impsort-maven-plugin.version>

--- a/starter-test/pom.xml
+++ b/starter-test/pom.xml
@@ -67,5 +67,10 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
+++ b/starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
@@ -1,18 +1,34 @@
 package io.javaoperatorsdk.operator.springboot.starter.test;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Primary;
 
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.sample.CustomService;
+import io.javaoperatorsdk.operator.sample.CustomServiceReconciler;
+import io.javaoperatorsdk.operator.sample.ServiceSpec;
+import io.javaoperatorsdk.operator.springboot.starter.OperatorConfigurationProperties;
+import io.javaoperatorsdk.operator.springboot.starter.ReconcilerProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @JsonTest
 @EnableMockOperator(crdPaths = "classpath:crd.yml")
@@ -45,6 +61,52 @@ class EnableMockOperatorTests {
                 .isNotNull();
   }
 
+  @Autowired
+  private OperatorConfigurationProperties operatorConfigurationProperties;
+
+  @Test
+  void customServiceReconciler() {
+    ReconcilerProperties properties =
+        operatorConfigurationProperties.getReconcilers().get("customservicereconciler");
+    assertNotNull(properties);
+    String testNS = "test-ns";
+    assertTrue(properties.getNamespaces().contains(testNS));
+    // create a namespace for testing
+    client.namespaces().create(namespace(testNS));
+    assertNotNull(client.namespaces().withName(testNS).get());
+    // create a CR
+    client.resources(CustomService.class).inNamespace(testNS)
+        .create(customService("test-name", "test-label"));
+    assertNotNull(client.resources(CustomService.class).inNamespace(testNS)
+        .withName("test-name").get());
+    // test if a service was created by the CustomServiceReconciler
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> assertNotNull(
+                client.resources(Service.class).inNamespace(testNS).withName("test-name").get()));
+  }
+
+  private Namespace namespace(String ns) {
+    return new NamespaceBuilder()
+        .withMetadata(
+            new ObjectMetaBuilder().withName(ns).build())
+        .build();
+  }
+
+  private CustomService customService(String name, String label) {
+    CustomService resource = new CustomService();
+    resource.setMetadata(
+        new ObjectMetaBuilder()
+            .withName(name)
+            .withResourceVersion("v1")
+            .build());
+    resource.setSpec(new ServiceSpec());
+    resource.getSpec().setName(name);
+    resource.getSpec().setLabel(label);
+    return resource;
+  }
+
   @SpringBootApplication
   @ComponentScan(
       includeFilters = {
@@ -54,5 +116,11 @@ class EnableMockOperatorTests {
           "io.javaoperatorsdk"
       })
   static class SpringBootTestApplication {
+    // Need to override the CustomServiceReconciler Bean to set KubernetesClient to the mocked one.
+    @Bean
+    @Primary
+    CustomServiceReconciler customServiceReconciler(KubernetesClient kubernetesClient) {
+      return new CustomServiceReconciler(kubernetesClient);
+    }
   }
 }

--- a/starter-test/src/test/resources/application.properties
+++ b/starter-test/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-javaoperatorsdk.test.global-crd-paths=classpath:global-crd.yml

--- a/starter-test/src/test/resources/application.yaml
+++ b/starter-test/src/test/resources/application.yaml
@@ -1,0 +1,13 @@
+javaoperatorsdk:
+  reconcilers:
+    customservicereconciler:
+      namespaces:
+        - test-ns
+      retry:
+        maxAttempts: 3
+  test:
+    global-crd-paths: classpath:global-crd.yml
+
+spring:
+  main:
+    allow-bean-definition-overriding: true


### PR DESCRIPTION
This is about [Issue 20](https://github.com/java-operator-sdk/operator-framework-spring-boot-starter/issues/20). I upgrade the  version of fabric8-server-mock and add a test about reconciler.