### PR TITLE
feat: support oauth token for explicitly cluster log on.

### DIFF
--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/KubernetesClientProperties.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/KubernetesClientProperties.java
@@ -8,6 +8,7 @@ public class KubernetesClientProperties {
   private String context;
   private String username;
   private String password;
+  private String oauthToken;
   private String masterUrl;
   private boolean trustSelfSignedCertificates = false;
 
@@ -43,6 +44,15 @@ public class KubernetesClientProperties {
 
   public KubernetesClientProperties setPassword(String password) {
     this.password = password;
+    return this;
+  }
+
+  public Optional<String> getOauthToken() {
+    return Optional.ofNullable(oauthToken);
+  }
+
+  public KubernetesClientProperties setOauthToken(String oauthToken) {
+    this.oauthToken = oauthToken;
     return this;
   }
 

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
@@ -39,6 +39,7 @@ public class AutoConfigurationTest {
     final var operatorProperties = config.getClient();
     assertEquals("user", operatorProperties.getUsername().get());
     assertEquals("password", operatorProperties.getPassword().get());
+    assertEquals("token", operatorProperties.getOauthToken().get());
     assertEquals("http://master.url", operatorProperties.getMasterUrl().get());
   }
 

--- a/starter/src/test/resources/application.yaml
+++ b/starter/src/test/resources/application.yaml
@@ -2,6 +2,7 @@ javaoperatorsdk:
   client:
     username: user
     password: password
+    oauthToken: token
     masterUrl: http://master.url
 
   reconcilers:


### PR DESCRIPTION
This is about [Issue 21](https://github.com/java-operator-sdk/operator-framework-spring-boot-starter/issues/21). 

If I'm right, the details about how fabric choose credentials can be found in method `io.fabric8.kubernetes.client.utils.HttpClientUtils#createApplicableInterceptors` of `kubernetes-client-5.12.2`. A piece of its source code is below:
```java
public static Map<String, io.fabric8.kubernetes.client.http.Interceptor> createApplicableInterceptors(Config config, HttpClient.Factory factory) {
    Map<String, io.fabric8.kubernetes.client.http.Interceptor> interceptors = new LinkedHashMap<>();
    
    // Header Interceptor
    interceptors.put(HEADER_INTERCEPTOR, new Interceptor() {
      
      @Override
      public void before(BasicBuilder builder, HttpHeaders headers) {
        if (Utils.isNotNullOrEmpty(config.getUsername()) && Utils.isNotNullOrEmpty(config.getPassword())) {
          builder.header("Authorization", basicCredentials(config.getUsername(), config.getPassword()));
        } else if (Utils.isNotNullOrEmpty(config.getOauthToken())) {
          builder.header("Authorization", "Bearer " + config.getOauthToken());
        }
        if (config.getCustomHeaders() != null && !config.getCustomHeaders().isEmpty()) {
          for (Map.Entry<String, String> entry : config.getCustomHeaders().entrySet()) {
            builder.header(entry.getKey(),entry.getValue());
          }
        }
        if (config.getUserAgent() != null && !config.getUserAgent().isEmpty()) {
          builder.setHeader("User-Agent", config.getUserAgent());
        }
      }
    });
// something else
}
```