### PR TITLE
add cloner override

### DIFF
--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
@@ -23,10 +23,7 @@ import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
-import io.javaoperatorsdk.operator.api.config.AbstractConfigurationService;
-import io.javaoperatorsdk.operator.api.config.AnnotationControllerConfiguration;
-import io.javaoperatorsdk.operator.api.config.RetryConfiguration;
-import io.javaoperatorsdk.operator.api.config.Utils;
+import io.javaoperatorsdk.operator.api.config.*;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 
@@ -38,6 +35,9 @@ public class OperatorAutoConfiguration extends AbstractConfigurationService {
 
   @Autowired
   private OperatorConfigurationProperties configuration;
+
+  @Autowired(required = false)
+  private Cloner cloner;
 
   @Autowired(required = false)
   private KubernetesConfigCustomizer configCustomizer;
@@ -211,5 +211,10 @@ public class OperatorAutoConfiguration extends AbstractConfigurationService {
   @Override
   public int concurrentReconciliationThreads() {
     return configuration.getConcurrentReconciliationThreads();
+  }
+
+  @Override
+  public Cloner getResourceCloner() {
+    return cloner != null ? cloner : super.getResourceCloner();
   }
 }

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
@@ -12,11 +12,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
+import io.javaoperatorsdk.operator.api.config.Cloner;
+import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -33,6 +33,12 @@ public class AutoConfigurationTest {
 
   @Autowired
   private List<Reconciler<?>> reconcilers;
+
+  @Autowired
+  private ConfigurationService configurationService;
+
+  @MockBean
+  private Cloner cloner;
 
   @Test
   public void loadsKubernetesClientPropertiesProperly() {
@@ -56,6 +62,13 @@ public class AutoConfigurationTest {
   @Test
   public void beansCreated() {
     assertNotNull(kubernetesClient);
+    assertNotNull(configurationService);
+  }
+
+  @Test
+  public void clonerIsOverridden() {
+    assertInstanceOf(OperatorAutoConfiguration.class, configurationService);
+    assertEquals(configurationService.getResourceCloner(), cloner);
   }
 
   @Test
@@ -63,4 +76,5 @@ public class AutoConfigurationTest {
     assertEquals(1, reconcilers.size());
     assertTrue(reconcilers.get(0) instanceof TestReconciler);
   }
+
 }


### PR DESCRIPTION
Right now the Cloner provided by default is a new instance of ObjectMapper and it is not possible to customize it by registering additional modules.