### PR TITLE
#34 Support Spring Boot 3

### DIFF
--- a/starter/src/main/resources/META-INF/spring.factories
+++ b/starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.javaoperatorsdk.operator.springboot.starter.OperatorAutoConfiguration

--- a/starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.javaoperatorsdk.operator.springboot.starter.OperatorAutoConfiguration


### PR DESCRIPTION
This MR adds support for Spring Boot 3.

There's one open question: Should we also update the `spring-boot.version`  to `3.0.5`? This would also [require updating to Java 17](https://spring.io/blog/2022/05/24/preparing-for-spring-boot-3-0#:~:text=Spring%20Boot%203.0%20will%20require,the%20latest%20LTS%20Java%20version).