### PR TITLE
feat: add missing JOSDK config options

### DIFF
--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorConfigurationProperties.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorConfigurationProperties.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.springboot.starter;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -15,6 +16,12 @@ public class OperatorConfigurationProperties {
   private boolean checkCrdAndValidateLocalModel = true;
   private int concurrentReconciliationThreads =
       ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER;
+  private Integer minConcurrentReconciliationThreads;
+  private Integer concurrentWorkflowExecutorThreads;
+  private Integer minConcurrentWorkflowExecutorThreads;
+  private Boolean closeClientOnStop;
+  private Boolean stopOnInformerErrorDuringStartup;
+  private Duration cacheSyncTimeout;
 
   public KubernetesClientProperties getClient() {
     return client;
@@ -46,5 +53,54 @@ public class OperatorConfigurationProperties {
 
   public void setConcurrentReconciliationThreads(int concurrentReconciliationThreads) {
     this.concurrentReconciliationThreads = concurrentReconciliationThreads;
+  }
+
+  public Integer getMinConcurrentReconciliationThreads() {
+    return minConcurrentReconciliationThreads;
+  }
+
+  public void setMinConcurrentReconciliationThreads(Integer minConcurrentReconciliationThreads) {
+    this.minConcurrentReconciliationThreads = minConcurrentReconciliationThreads;
+  }
+
+  public Integer getConcurrentWorkflowExecutorThreads() {
+    return concurrentWorkflowExecutorThreads;
+  }
+
+  public void setConcurrentWorkflowExecutorThreads(Integer concurrentWorkflowExecutorThreads) {
+    this.concurrentWorkflowExecutorThreads = concurrentWorkflowExecutorThreads;
+  }
+
+  public Integer getMinConcurrentWorkflowExecutorThreads() {
+    return minConcurrentWorkflowExecutorThreads;
+  }
+
+  public void setMinConcurrentWorkflowExecutorThreads(
+      Integer minConcurrentWorkflowExecutorThreads) {
+    this.minConcurrentWorkflowExecutorThreads = minConcurrentWorkflowExecutorThreads;
+  }
+
+  public Boolean getCloseClientOnStop() {
+    return closeClientOnStop;
+  }
+
+  public void setCloseClientOnStop(Boolean closeClientOnStop) {
+    this.closeClientOnStop = closeClientOnStop;
+  }
+
+  public Boolean getStopOnInformerErrorDuringStartup() {
+    return stopOnInformerErrorDuringStartup;
+  }
+
+  public void setStopOnInformerErrorDuringStartup(Boolean stopOnInformerErrorDuringStartup) {
+    this.stopOnInformerErrorDuringStartup = stopOnInformerErrorDuringStartup;
+  }
+
+  public Duration getCacheSyncTimeout() {
+    return cacheSyncTimeout;
+  }
+
+  public void setCacheSyncTimeout(Duration cacheSyncTimeout) {
+    this.cacheSyncTimeout = cacheSyncTimeout;
   }
 }

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/ReconcilerProperties.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/ReconcilerProperties.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.springboot.starter;
 
+import java.time.Duration;
 import java.util.Set;
 
 public class ReconcilerProperties {
@@ -9,6 +10,8 @@ public class ReconcilerProperties {
   private Boolean clusterScoped;
   private Set<String> namespaces;
   private RetryProperties retry;
+  private String labelSelector;
+  private Duration reconciliationMaxInterval;
 
   public String getName() {
     return name;
@@ -56,5 +59,21 @@ public class ReconcilerProperties {
 
   public void setRetry(RetryProperties retry) {
     this.retry = retry;
+  }
+
+  public String getLabelSelector() {
+    return labelSelector;
+  }
+
+  public void setLabelSelector(String labelSelector) {
+    this.labelSelector = labelSelector;
+  }
+
+  public Duration getReconciliationMaxInterval() {
+    return reconciliationMaxInterval;
+  }
+
+  public void setReconciliationMaxInterval(Duration reconciliationMaxInterval) {
+    this.reconciliationMaxInterval = reconciliationMaxInterval;
   }
 }

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.springboot.starter;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -78,13 +79,20 @@ public class AutoConfigurationTest {
 
   @Test
   public void configServiceOverridesAppliedInCorrectOrder() {
-    var configurationService = ConfigurationServiceProvider.instance();
+    var configService = ConfigurationServiceProvider.instance();
 
     assertThat(config.getConcurrentReconciliationThreads())
-        .isNotEqualTo(CUSTOM_RECONCILE_THREADS);
-    assertThat(configurationService.concurrentReconciliationThreads())
+        .isEqualTo(6).isNotEqualTo(CUSTOM_RECONCILE_THREADS);
+    assertThat(configService.concurrentReconciliationThreads())
         .isEqualTo(CUSTOM_RECONCILE_THREADS);
-    assertEquals(configurationService.getResourceCloner(), cloner);
+    assertEquals(configService.getResourceCloner(), cloner);
+    assertThat(configService.cacheSyncTimeout()).isEqualTo(Duration.ofDays(17));
+    assertThat(configService.closeClientOnStop()).isFalse();
+    assertThat(configService.stopOnInformerErrorDuringStartup()).isFalse();
+    assertThat(configService.checkCRDAndValidateLocalModel()).isFalse();
+    assertThat(configService.concurrentWorkflowExecutorThreads()).isEqualTo(12);
+    assertThat(configService.minConcurrentReconciliationThreads()).isEqualTo(22);
+    assertThat(configService.minConcurrentWorkflowExecutorThreads()).isEqualTo(32);
   }
 
   @Test
@@ -105,6 +113,8 @@ public class AutoConfigurationTest {
                 assertThat(config.isGenerationAware()).isTrue();
                 assertThat(config.getName()).isEqualTo("not-a-test-reconciler");
                 assertThat(config.getFinalizerName()).isEqualTo("barton.fink/1991");
+                assertThat(config.getLabelSelector()).isEqualTo("version in (v1)");
+                assertThat(config.maxReconciliationInterval()).hasValue(Duration.ofMinutes(3));
               });
           assertThat(controller.getConfiguration().getRetry())
               .isInstanceOfSatisfying(GenericRetry.class, retry -> {

--- a/starter/src/test/resources/application.yaml
+++ b/starter/src/test/resources/application.yaml
@@ -1,4 +1,13 @@
 javaoperatorsdk:
+  cache-sync-timeout: 17d
+  close-client-on-stop: false
+  concurrent-reconciliation-threads: 6
+  stop-on-informer-error-during-startup: false
+  check-crd-and-validate-local-model: false
+  concurrent-workflow-executor-threads: 12
+  min-concurrent-reconciliation-threads: 22
+  min-concurrent-workflow-executor-threads: 32
+
   client:
     username: user
     password: password
@@ -14,6 +23,8 @@ javaoperatorsdk:
       generationAware: true
       finalizerName: "barton.fink/1991"
       name: "not-a-test-reconciler"
+      reconciliation-max-interval: 3m
+      labelSelector: "version in (v1)"
       retry:
         maxAttempts: 3
         initialInterval: 1000


### PR DESCRIPTION
closes #35 

`TerminationTimeoutSeconds` was not added because it is [deprecated](https://github.com/java-operator-sdk/java-operator-sdk/blob/92c89bf08a82a52599f8246ec7407c63669108e9/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java#L153C1-L154) in the service, although it isn't deprecated in the overrider - is that intentional?

Also it would be cool to modify the readme to include an embedded markdown of the test `app.yaml` file with all the properties. Unfortunately, I can't do this because it needs a permalink to be rendered on github, but I would be generating a permalink to my fork, and it only renders what is within the current repo.