### PR TITLE
Update to use Spring Boot 4.0.0 without updating to Jackson 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <spotless.version>3.1.0</spotless.version>
     <josdk.version>5.2.0</josdk.version>
-    <spring-boot.version>3.5.8</spring-boot.version>
+    <spring-boot.version>4.0.0</spring-boot.version>
     <surefire.version>3.5.4</surefire.version>
     <fabric8-client.version>7.3.1</fabric8-client.version>
     <jenvtest.version>0.9.7</jenvtest.version>

--- a/starter-test/pom.xml
+++ b/starter-test/pom.xml
@@ -83,6 +83,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
+++ b/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
@@ -3,7 +3,7 @@ package io.javaoperatorsdk.operator.springboot.starter.test;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import org.springframework.boot.test.autoconfigure.properties.PropertyMapping;
+import org.springframework.boot.test.context.PropertyMapping;
 import org.springframework.context.annotation.Import;
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/HealthIndicatorTest.java
+++ b/starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/HealthIndicatorTest.java
@@ -3,29 +3,29 @@ package io.javaoperatorsdk.operator.springboot.starter.test;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
     "management.endpoint.health.enabled=true", "management.endpoint.health.show-details=always"})
 @EnableMockOperator(crdPaths = "classpath:crd.yml")
+@AutoConfigureMockMvc
 class HealthIndicatorTest {
 
   @Autowired
-  private TestRestTemplate restTemplate;
+  private MockMvc mockMvc;
 
   @Test
-  void testOperatorHealthIndicator() {
-    ResponseEntity<String> entity =
-        this.restTemplate.getForEntity("/actuator/health", String.class);
-    assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(entity.getBody()).contains("\"status\":\"UP\"");
-    assertThat(entity.getBody())
-        .contains(
-            "\"operator\":{\"status\":\"UP\",\"details\":{\"customservicereconciler\":\"OK\"}}");
+  void testOperatorHealthIndicator() throws Exception {
+    mockMvc.perform(get("/actuator/health"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("UP"))
+        .andExpect(jsonPath("$.components.operator.status").value("UP"))
+        .andExpect(jsonPath("$.components.operator.details.customservicereconciler").value("OK"));
   }
 
 }

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -57,6 +57,16 @@
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-health</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jackson2</artifactId>
+      <optional>true</optional>
+    </dependency>
     <!-- without this, the app exits after 1 minute  -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorHealthIndicator.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorHealthIndicator.java
@@ -2,8 +2,8 @@ package io.javaoperatorsdk.operator.springboot.starter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.actuate.health.AbstractHealthIndicator;
-import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.health.contributor.AbstractHealthIndicator;
+import org.springframework.boot.health.contributor.Health;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 


### PR DESCRIPTION
I noticed that the PR generated by dependabot fails since it only updates the Spring Boot version. So I've created this branch with the necessary changes to code and build files. (see https://github.com/operator-framework/josdk-spring-boot-starter/pull/264)

**pom.xml**
* Just bumps the Spring Boot BOM version to 4.0.0

**starter-test/pom.xml**
* Added `org.springframework.boot:spring-boot-starter-webmvc-test` dependency since the servlet related test classes had been moved to this new module
* 

**starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java**
* The `org.springframework.boot.test.autoconfigure.properties.PropertyMapping` class was moved to the `org.springframework.boot.test.context` package.

**starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/HealthIndicatorTest.java**
* I changed the test to use `MockMvc` instead of `TestRestTemplate`
* Used `jsonPath()` to more precisely test the results without depending on formatting  and ordering of the JSON response.

**starter/pom.xml**
* Added `org.springframework.boot:spring-boot-health` dependency since the health indicator classes have been moved to this module
* Added `org.springframework.boot:spring-boot-jackson2` since the Fabric8 Kubernetes client is still using Jackson 2 while Spring Boot 4 has been updated to use Jackson 3 by default.

**starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorHealthIndicator.java**
* The `org.springframework.boot.actuate.health.AbstractHealthIndicator` class was moved to the `org.springframework.boot.health.contributor.` package.
* The `org.springframework.boot.actuate.health.Health` class was moved to the `org.springframework.boot.health.contributor.` package.
